### PR TITLE
Better handling of unicode supplementary chars

### DIFF
--- a/picnic/src/main/java/com/jakewharton/picnic/textLayout.kt
+++ b/picnic/src/main/java/com/jakewharton/picnic/textLayout.kt
@@ -60,9 +60,8 @@ internal class SimpleLayout(private val cell: PositionedCell) : TextLayout {
     var x = left
     var y = top
     //Iterate through codepoints in input string
-    for (index in 0 until cell.cell.content.unicodeLength) {
+    for (codePoint in cell.cell.content.codePoints()) {
       // TODO invisible chars, graphemes, etc.
-      val codePoint = cell.cell.content.codePointAt(index)
       if (codePoint != '\n'.toInt()) {
         canvas[y, x++] = codePoint
       } else {

--- a/picnic/src/main/java/com/jakewharton/picnic/textSurface.kt
+++ b/picnic/src/main/java/com/jakewharton/picnic/textSurface.kt
@@ -4,29 +4,30 @@ internal class TextSurface(
   override val width: Int,
   override val height: Int
 ) : TextCanvas {
-  private val buffer = IntArray(height * (width + 1)) { index ->
-    val charValue = if (index % (width + 1) == width) '\n' else ' '
-    charValue.toInt()
+  private val buffer = IntArray(height * width) { _ ->
+    ' '.toInt()
   }
 
   override operator fun set(row: Int, column: Int, char: Int) {
     require(row in 0 until height) { "Row $row not in range [0, $height)" }
     require(column in 0 until width) { "Column $column not in range [0, $width)" }
-    buffer[row * (width + 1) + column] = char
+    buffer[row * width + column] = char
   }
 
   override fun get(row: Int, column: Int): Int {
     require(row in 0 until height) { "Row $row not in range [0, $height)" }
     require(column in 0 until width) { "Column $column not in range [0, $width)" }
-    return buffer[row * (width + 1) + column]
+    return buffer[row * width + column]
   }
 
   /**
    * buffer is array of codepoints, convert back to chars
    */
   override fun toString() = StringBuilder(buffer.size * 2).apply {
-      buffer.forEach { codePoint ->
+      buffer.forEachIndexed { index, codePoint ->
         append(Character.toChars(codePoint))
+
+        if (index % width == width - 1) appendln()
       }
     }.toString()
 }

--- a/picnic/src/main/java/com/jakewharton/picnic/textSurface.kt
+++ b/picnic/src/main/java/com/jakewharton/picnic/textSurface.kt
@@ -4,36 +4,40 @@ internal class TextSurface(
   override val width: Int,
   override val height: Int
 ) : TextCanvas {
-  private val buffer = StringBuilder(height * (width + 1)).apply {
-    repeat(height) {
-      repeat(width) {
-        append(' ')
-      }
-      append('\n')
-    }
+  private val buffer = IntArray(height * (width + 1)) { index ->
+    val charValue = if (index % (width + 1) == width) '\n' else ' '
+    charValue.toInt()
   }
 
-  override operator fun set(row: Int, column: Int, char: Char) {
+  override operator fun set(row: Int, column: Int, char: Int) {
     require(row in 0 until height) { "Row $row not in range [0, $height)" }
     require(column in 0 until width) { "Column $column not in range [0, $width)" }
     buffer[row * (width + 1) + column] = char
   }
 
-  override fun get(row: Int, column: Int): Char {
+  override fun get(row: Int, column: Int): Int {
     require(row in 0 until height) { "Row $row not in range [0, $height)" }
     require(column in 0 until width) { "Column $column not in range [0, $width)" }
     return buffer[row * (width + 1) + column]
   }
 
-  override fun toString() = buffer.toString()
+  /**
+   * buffer is array of codepoints, convert back to chars
+   */
+  override fun toString() = StringBuilder(buffer.size * 2).apply {
+      buffer.forEach { codePoint ->
+        append(Character.toChars(codePoint))
+      }
+    }.toString()
 }
 
 interface TextCanvas {
   val width: Int
   val height: Int
 
-  operator fun set(row: Int, column: Int, char: Char)
-  operator fun get(row: Int, column: Int): Char
+  operator fun set(row: Int, column: Int, char: Char) = set(row, column, char.toInt())
+  operator fun set(row: Int, column: Int, char: Int)
+  operator fun get(row: Int, column: Int): Int
 
   @JvmDefault
   fun clip(left: Int, right: Int, top: Int, bottom: Int): TextCanvas {
@@ -51,13 +55,13 @@ private class ClippedTextCanvas(
   override val width = right - left
   override val height = bottom - top
 
-  override fun set(row: Int, column: Int, char: Char) {
+  override fun set(row: Int, column: Int, char: Int) {
     require(row in 0 until height) { "Row $row not in range [0, $height)" }
     require(column in 0 until width) { "Column $column not in range [0, $width)" }
     canvas[top + row, left + column] = char
   }
 
-  override fun get(row: Int, column: Int): Char {
+  override fun get(row: Int, column: Int): Int {
     require(row in 0 until height) { "Row $row not in range [0, $height)" }
     require(column in 0 until width) { "Column $column not in range [0, $width)" }
     return canvas[top + row, left + column]

--- a/picnic/src/test/java/com/jakewharton/picnic/CellSizeTest.kt
+++ b/picnic/src/test/java/com/jakewharton/picnic/CellSizeTest.kt
@@ -120,4 +120,23 @@ class CellSizeTest {
       |   1     
       |""".trimMargin())
   }
+
+  @Test fun unicode() {
+    val table = table {
+      row('\u0031') //1 utf-8 bytes
+      row('\u00A3') //2 utf-8 bytes
+      row('\u20AC') //3 utf-8 bytes
+      row('\u5317') //3 utf-8 bytes, full-width
+      row(String(Character.toChars(0x1F603))) //4 utf-8 bytes (2*utf-16), full-width
+    }
+
+    assertThat(table.renderText()).isEqualTo("""
+      |1
+      |£
+      |€
+      |北
+      |😃
+      |""".trimMargin())
+
+  }
 }

--- a/picnic/src/test/java/com/jakewharton/picnic/CellSizeTest.kt
+++ b/picnic/src/test/java/com/jakewharton/picnic/CellSizeTest.kt
@@ -137,6 +137,22 @@ class CellSizeTest {
       |北
       |😃
       |""".trimMargin())
+  }
+
+  //Rows contain mixture of BMP and supplementary codepoints. This exercises a bug in the initial
+  //codepoint implementation
+  @Test fun mixedWidth() {
+    val table = table {
+      row() //Should be 5 spaces
+      row("😃.😃.😃") //2 utf-8 bytes
+      row(".😃.😃.") //2 utf-8 bytes
+    }
+
+    assertThat(table.renderText()).isEqualTo("""
+      |     
+      |😃.😃.😃
+      |.😃.😃.
+      |""".trimMargin())
 
   }
 }


### PR DESCRIPTION
Supplementary characters require 2 java/ kotlin
chars to store but are rendered as a single
character. This caused problems for a lot of
places that assumed length = number of chars.

Replaced the buffer in TextSurface to be an array
of codepoints (int) rather than a plain String (which
would have an undefined length if surrogate pairs are
used). Iterate through the codepoints rather than chars.

Note this is more consistent but not necessarily
always better than to measuring these as 2 chars.
Text measurement is complicated and I'll add more
context to #4

Another note: I think some of these APIs only work on kotlin
JVM which may be a problem for #8 but should be simple to
port if needed (http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/dc4322602480/src/share/classes/java/lang/Character.java)