### PR TITLE
Helper for adding multiple cells at once

### DIFF
--- a/picnic/src/main/java/com/jakewharton/picnic/dsl.kt
+++ b/picnic/src/main/java/com/jakewharton/picnic/dsl.kt
@@ -41,6 +41,11 @@ interface TableSectionDsl {
 interface RowDsl {
   fun cell(content: Any?, style: CellDsl.() -> Unit = {})
 
+  @JvmDefault
+  fun cells(vararg content: Any?, style: CellDsl.() -> Unit = {}) {
+    content.forEach { cell(it, style) }
+  }
+
   fun cellStyle(content: CellStyleDsl.() -> Unit)
 }
 

--- a/picnic/src/test/java/com/jakewharton/picnic/DslTest.kt
+++ b/picnic/src/test/java/com/jakewharton/picnic/DslTest.kt
@@ -1,0 +1,23 @@
+package com.jakewharton.picnic
+
+import com.google.common.truth.Truth.assertThat
+import com.jakewharton.picnic.TextAlignment.BottomCenter
+import org.junit.Test
+
+class DslTest {
+  @Test fun cellsAppliesStyleToEachCell() {
+    val table = table {
+      row {
+        cells("a", "b\nb", "c\nc\nc") {
+          alignment = BottomCenter
+        }
+      }
+    }
+
+    assertThat(table.renderText()).isEqualTo("""
+      |  c
+      | bc
+      |abc
+      |""".trimMargin())
+  }
+}


### PR DESCRIPTION
Changing from row(.., ..) to cell(..);cell(..) is annoying when you have a single conditional cell. This allows you to retain the single call for the rest.