### PR TITLE
Fix compilation on Windows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,5 @@
 [*.{kt,kts}]
+indent_style = space
 indent_size=2
 continuation_indent_size=4
 insert_final_newline=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      # ensure we get results for all matrix jobs
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Build/Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.11
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build --info

--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,9 @@ buildscript {
   ]
 
   dependencies {
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10"
-    classpath 'org.jlleitschuh.gradle:ktlint-gradle:9.1.0'
-    classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.10.0'
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.30"
+    classpath 'org.jlleitschuh.gradle:ktlint-gradle:10.0.0'
+    classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.30'
     classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.5.0'
   }
 
@@ -32,7 +32,7 @@ subprojects {
 
   apply plugin: 'org.jlleitschuh.gradle.ktlint'
   ktlint {
-    version = '0.38.1'
+    version = '0.40.0'
     disabledRules = [
         'filename',
     ]

--- a/picnic/build.gradle
+++ b/picnic/build.gradle
@@ -4,6 +4,8 @@ java {
   targetCompatibility = JavaVersion.VERSION_1_8
   withSourcesJar()
 }
+compileJava.options.encoding = "UTF-8"
+compileTestJava.options.encoding = "UTF-8"
 
 apply plugin: 'org.jetbrains.kotlin.jvm'
 compileKotlin {

--- a/picnic/build.gradle
+++ b/picnic/build.gradle
@@ -24,9 +24,8 @@ dependencies {
 }
 
 apply plugin: 'org.jetbrains.dokka'
-def dokkaDir = "$buildDir/dokka"
-dokka {
-  outputFormat = 'html'
+def dokkaDir = new File(buildDir, "dokka")
+dokkaHtml {
   outputDirectory = dokkaDir
 }
 def dokkaJarTaskProvider = tasks.register('dokkaJar', Jar) { task ->
@@ -35,12 +34,12 @@ def dokkaJarTaskProvider = tasks.register('dokkaJar', Jar) { task ->
   task.dependsOn('dokka')
 }
 
-def javadocJarTaskProvider = tasks.register('javadocJar', org.jetbrains.dokka.gradle.DokkaTask) { task ->
-  task.outputFormat = 'javadoc'
-  task.outputDirectory = "$buildDir/javadoc"
+dokkaJavadoc {
+  outputDirectory = new File(buildDir, 'javadoc')
 }
+
 tasks.named('assemble').configure {
-  it.dependsOn(javadocJarTaskProvider)
+  it.dependsOn(dokkaJavadoc)
 }
 
 def isReleaseBuild = !version.endsWith('-SNAPSHOT')


### PR DESCRIPTION
The file encoding needs to be set to UTF-8. I'm honestly not 
sure why this is required, given that Kotlin files are supposed to
always be UTF-8.

Fixes #29.